### PR TITLE
Swap out single quotes for backticks

### DIFF
--- a/components/map/default.htm
+++ b/components/map/default.htm
@@ -44,7 +44,7 @@
             {% endif %}
             var mapObject{{ loop.index }} = L.{{ object.type }}([{{ object.position|trim }}], parameters).addTo({{ map.fieldId }});
             {% if object.popup %}
-                mapObject{{ loop.index }}.bindPopup('{{ object.popup|replace({"\n":'', "\r":''})|trim|raw }}');
+                mapObject{{ loop.index }}.bindPopup(`{{ object.popup|replace({"\n":'', "\r":''})|trim|raw }}`);
             {% endif %}
         {% endfor %}
     </script>


### PR DESCRIPTION
If you try to bind a pop-up with an apostrophe in, then it will cause an error and the map won't load. Switching to template literals fixes this. Although this is arguably not a safe way to do this, it is no worse than it currently is. (eg: you could write a 'popup' containing the text `'); alert('xss');var ignore = '` which would also allow XSS attacks. This fixes for my purposes now, but I'll open an 'issue' for the XSS vulnerability.